### PR TITLE
Bnb/eagle

### DIFF
--- a/nsrdb/cli.py
+++ b/nsrdb/cli.py
@@ -53,15 +53,16 @@ def main(ctx):
 
 
 @main.command()
-@click.option('--args', '-a', required=True, type=DICT,
+@click.option('--kwargs', '-kw', required=True, type=DICT,
               help='Argument dictionary. Needs to include year. '
-              'e.g. {"year":2019, "freq":"5min"} ')
+              'e.g. {"year":2019, "freq":"5min"} . Available keys: '
+              'year, freq, outdir, sat, reg, basename. ')
 @click.pass_context
-def create_configs(ctx, args):
+def create_configs(ctx, kwargs):
     """NSRDB config file creation from templates."""
 
     ctx.ensure_object(dict)
-    NSRDB.create_config_files(args)
+    NSRDB.create_config_files(kwargs)
 
 
 @main.command()

--- a/nsrdb/config/templates/config_nsrdb_post2017.json
+++ b/nsrdb/config/templates/config_nsrdb_post2017.json
@@ -59,7 +59,7 @@
   },
   "direct": {
     "log_level": "INFO",
-    "name": "%basename%_%sat%_%year%",
+    "name": "%basename%_%sat%_%reg%_%year%",
     "nsrdb_freq": "%freq%",
     "nsrdb_grid": "/projects/pxs/reference_grids/surfrad_meta_extended.csv",
     "out_dir": "./",

--- a/nsrdb/config/templates/config_nsrdb_pre2018.json
+++ b/nsrdb/config/templates/config_nsrdb_pre2018.json
@@ -13,79 +13,43 @@
     ],
     "factory_kwargs": {
       "cld_opd_dcomp": {
-        "parallax_correct": true,
-        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5",
-        "remap_pc": false,
-        "solar_shading": false
+        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5"
       },
       "cld_press_acha": {
-        "parallax_correct": true,
-        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5",
-        "remap_pc": false,
-        "solar_shading": false
+        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5"
       },
       "cld_reff_dcomp": {
-        "parallax_correct": true,
-        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5",
-        "remap_pc": false,
-        "solar_shading": false
+        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5"
       },
       "cloud_fraction": {
-        "parallax_correct": true,
-        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5",
-        "remap_pc": false,
-        "solar_shading": false
+        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5"
       },
       "cloud_probability": {
-        "parallax_correct": true,
-        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5",
-        "remap_pc": false,
-        "solar_shading": false
+        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5"
       },
       "cloud_type": {
-        "parallax_correct": true,
-        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5",
-        "remap_pc": false,
-        "solar_shading": false
+        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5"
       },
       "refl_0_65um_nom": {
-        "parallax_correct": true,
-        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5",
-        "remap_pc": false,
-        "solar_shading": false
+        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5"
       },
       "refl_0_65um_nom_stddev_3x3": {
-        "parallax_correct": true,
-        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5",
-        "remap_pc": false,
-        "solar_shading": false
+        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5"
       },
       "refl_3_75um_nom": {
-        "parallax_correct": true,
-        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5",
-        "remap_pc": false,
-        "solar_shading": false
+        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5"
       },
       "surface_albedo": {
-        "source_dir": "/projects/pxs/ancillary/albedo/nsrdb_%year%/"
+        "source_dir": "/projects/pxs/ancillary/albedo/nsrdb_%year%/{doy}.h5"
       },
       "temp_11_0um_nom": {
-        "parallax_correct": true,
-        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5",
-        "remap_pc": false,
-        "solar_shading": false
+        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5"
       },
       "temp_11_0um_nom_stddev_3x3": {
-        "parallax_correct": true,
-        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5",
-        "remap_pc": false,
-        "solar_shading": false
+        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5"
       },
       "temp_3_75um_nom": {
-        "parallax_correct": true,
-        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5",
-        "remap_pc": false,
-        "solar_shading": false
+        "pattern": "/lustre/eaglefs/projects/pxs/HDF/%sat%/%year%/{doy}/level2/clavrx_goes13_%year%_*.h5"
       }
     },
     "max_workers": null,

--- a/nsrdb/config/templates/config_pipeline.json
+++ b/nsrdb/config/templates/config_pipeline.json
@@ -4,7 +4,7 @@
     "log_file": null,
     "log_level": "INFO"
   },
-  "name": "%basename%_%sat%_%year%",
+  "name": "%basename%_%sat%_%reg%_%year%",
   "pipeline": [
     {
       "data-model": "./config_nsrdb.json"


### PR DESCRIPTION
Added routine to `nsrdb,py` which replaces` {year}, {basename}, {freq}, {hemi}` in template config files and copies these populated config files into `{outdir}`. This is called through cli with `python -m nsrdb.cli create-configs`. This can be used to generate config files for a specific year instead of having to change all the file names manually. Not sure if this is worth adding but I think it could be helpful as we move to automate the runs more. 